### PR TITLE
Fix deprecated devtools::install_github in CI workflows

### DIFF
--- a/.github/workflows/afltables_scraper.yaml
+++ b/.github/workflows/afltables_scraper.yaml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
       - name: Install Dependencies
-        run: Rscript -e 'install.packages(c("devtools", "tidyverse", "here", "fst", "cli"))'
+        run: Rscript -e 'install.packages(c("tidyverse", "here", "fst", "cli"))'
       - name: Install fitzRoy
-        run: Rscript -e 'devtools::install_github("jimmyday12/fitzRoy")'
+        run: Rscript -e 'pak::pak("jimmyday12/fitzRoy")'
       - name: Get data
         run: Rscript -e 'source(here::here("scripts", "afltables_weekly_script.R"), echo = TRUE)'
       - name: Commit

--- a/.github/workflows/footywire_scraper.yaml
+++ b/.github/workflows/footywire_scraper.yaml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
       - name: Install Dependencies
-        run: Rscript -e 'install.packages(c("devtools", "tidyverse", "here", "fst", "cli"))'
+        run: Rscript -e 'install.packages(c("tidyverse", "here", "fst", "cli"))'
       - name: Install fitzRoy
-        run: Rscript -e 'devtools::install_github("jimmyday12/fitzRoy")'
+        run: Rscript -e 'pak::pak("jimmyday12/fitzRoy")'
       - name: Get data
         run: Rscript -e 'source(here::here("scripts", "footywire_weekly_script.R"), echo = TRUE)'
       - name: Commit


### PR DESCRIPTION
## Summary
- `devtools::install_github()` was deprecated in devtools 2.5.0 and now throws a hard error, breaking both fetch data workflows
- Replaced with `pak::pak()` as recommended by the devtools deprecation message
- Removed `devtools` from `install.packages()` since it is no longer needed

## Test plan
- [ ] Manually trigger `fetch footywire data weekly` via workflow_dispatch and confirm "Install fitzRoy" step passes
- [ ] Manually trigger `fetch afltables data weekly` via workflow_dispatch and confirm "Install fitzRoy" step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)