### PR TITLE
Fix footywire scraper: send browser User-Agent

### DIFF
--- a/scripts/footywire_weekly_script.R
+++ b/scripts/footywire_weekly_script.R
@@ -10,6 +10,10 @@ library(fitzRoy)
 library(cli)
 library(arrow)
 
+# footywire.com returns HTTP 406 for requests without a browser-like
+# User-Agent, which breaks xml2::read_html() calls inside fitzRoy.
+options(HTTPUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36")
+
 # Variables
 end_year <- as.numeric(format(Sys.Date(), "%Y"))
 total_seasons <- 1897:end_year


### PR DESCRIPTION
## Summary
- The `scrape-and-commit` job in `fetch footywire data weekly` has been failing on every scheduled run (and on a manual `workflow_dispatch` run I triggered) with `Error in open.connection(): cannot open the connection` while calling `fitzRoy::fetch_player_stats_footywire()`.
- Root cause: footywire.com now returns `HTTP 406` for requests that don't send a browser-like `User-Agent`. `xml2::read_html()` (used internally by fitzRoy's footywire scrapers) uses R's default User-Agent, which the site rejects.
- Confirmed locally: `httr::GET()` against `ft_match_list?year=2026` returns 406 with the default UA, and 200 once a browser UA is set. Setting `options(HTTPUserAgent = ...)` before calling into fitzRoy fixes `fetch_footywire_match_ids()` (returns match IDs successfully instead of erroring).
- Fix: set a browser `User-Agent` via `options(HTTPUserAgent = ...)` at the top of `scripts/footywire_weekly_script.R`, before any fitzRoy calls, so all `xml2::read_html()` calls in the session send it.

## Test plan
- [x] Reproduced the 406 locally against footywire.com with the default R UA
- [x] Confirmed `fetch_footywire_match_ids(season = 2026)` succeeds with the UA option set (162 match IDs returned)
- [ ] Confirm the scheduled/manual GitHub Actions run of `fetch footywire data weekly` succeeds end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)